### PR TITLE
Specs publish without versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,14 @@ args:
 
 flags:
 
--t -—type           enum(’consumer’, ‘provider’)
+-t -—type         	the type of service contract (either 'consumer' or 'provider')
 
--v -—version        (optional, defaults to SHA of git commit)
+-b -—branch       	git branch name (optional)
 
--b -—branch         (optional)
+-v -—version      	version of service (only for --type 'consumer', defaults to SHA of git commit)
 
--n -—provider-name  (only for -—type ‘provider’)
+-n -—provider-name 	identifier key for provider service (only for —-type 'provider')
+
 
 # Publishing a Contract (in development)
 

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -56,13 +56,13 @@ publish [path to contract] [broker url]
 
 flags:
 
--t -—type         	enum('consumer', 'provider')
+-t -—type         	the type of service contract (either 'consumer' or 'provider')
 
--v -—version      	service version
+-b -—branch       	git branch name (optional)
 
--b -—branch       	git branch name
+-v -—version      	version of service (only for --type 'consumer', defaults to SHA of git commit)
 
--n -—provider-name (only for —type 'provider') name of provider service
+-n -—provider-name 	identifier key for provider service (only for —-type 'provider')
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
@@ -88,6 +88,10 @@ flags:
 		var name string
 		if Type == "provider" {
 			name = ProviderName
+
+			if len(Version) != 0 {
+				Version = ""
+			}
 		} else {
 			name, err = ConsumerName(path)
 			if err != nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -12,7 +12,7 @@ func TestCLIBaseCommand(t *testing.T) {
 	RootCmd.SetArgs([]string{})
 	RootCmd.Execute()
 
-	expected := "This command line interface is used to publish contracts"
+	expected := "A command line interface for the contract broker"
 	actualOutput := actual.String()
 
 	if actualOutput[:len(expected)] != expected {


### PR DESCRIPTION
Updates the "publish" command to ignore the value of the --version flag if the --type is 'provider'. API specs are not associated with provider implementations when the specs are published.