### PR TITLE
Publish spec no version

### DIFF
--- a/.signetrc.yaml
+++ b/.signetrc.yaml
@@ -3,7 +3,7 @@ broker-url: http://localhost:3000
 publish:
   type: provider
   path: ./data_test/api-spec.json
-  provider-name: user_service
+  name: user_service
 
 update-deployment:
   name: user_service

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ flags:
 
 -t -—type           the type of service contract (either 'consumer' or 'provider')
 
--n -—provider-name  canonical name of the provider service (only for —-type 'provider')
+-n -—name           canonical name of the provider service (only for —-type 'provider')
 
 -v -—version        service version (required for --type 'consumer')
 -—type=consumer: if flag not passed or passed without value, defaults to the git SHA of HEAD
@@ -83,7 +83,7 @@ broker-url: http://localhost:3000
 publish:
   type: provider
   path: ./data_test/api-spec.json
-  provider-name: user_service
+  name: user_service
 ```
 
 #### Publishing a Consumer Contract (binary - with explicit flags)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ Every signet command supports `--help` flag, for example:
 
 ## `signet publish`
 
-- The `publish` command pushes a local contract or spec to the broker. This automatically triggers contract/spec comparison if the broker already has a contract for the other participant in the integration.
+- The `publish` command pushes a local contract or API spec to the broker. This automatically triggers contract/spec comparison if the broker already has a contract or API spec for the other participant in the integration.
+
+- When publishing a consumer contract, it required to pass a `--version`. This is used to inform the Signet broker of which versions of the consumer service the consumer contract is tested against.
+
+- When publishing a provider spec, `--version` and `--branch` flags are ignored. Versions of a provider service are proven to correctly implement an API spec with the `signet test` command. A passing `signet test` will inform the Signet broker of which versions of the provider service are tested against the API spec.
 
 ```bash
 flags:
@@ -54,11 +58,9 @@ flags:
 
 -n -—name           canonical name of the provider service (only for —-type 'provider')
 
--v -—version        service version (required for --type 'consumer')
--—type=consumer: if flag not passed or passed without value, defaults to the git SHA of HEAD
--—type=provider: if the flag passed without value, defaults to git SHA
+-v -—version        service version (only for --type 'consumer', if flag not passed or passed without value, defaults to the git SHA of HEAD)
 
--b -—branch         git branch name (optional, defaults to current git branch)
+-b -—branch         git branch name (optional, only for --type 'consumer', defaults to git branch of HEAD)
 
 -u --broker-url     the scheme, domain, and port where the Signet Broker is being hosted (ex. http://localhost:3000)
 
@@ -95,7 +97,7 @@ signet publish --path=./data_test/cons-prov.json --broker-url=http://localhost:3
 #### Publish a Provider Specification (binary - yaml, with explicit flags)
 
 ```bash
-signet publish --path=./data_test/api-spec.yaml --broker-url=http://localhost:3000 --type provider --provider-name example-provider
+signet publish --path=./data_test/api-spec.yaml --broker-url=http://localhost:3000 --type provider --name=example-provider
 ```
 
 ## `signet test`
@@ -106,17 +108,17 @@ signet publish --path=./data_test/api-spec.yaml --broker-url=http://localhost:30
 ```bash
 flags:
 
--n --name 					the name of the provider service
+-n --name           the name of the provider service
 
--v --version        the version of the provider service
+-v --version        the version of the provider service (required, passing --version without a value will default to git SHA of HEAD)
 
--b --branch         Version control branch (optional)
+-b --branch         version control branch (passing --branch without a value will default to git branch of HEAD)
 
 -s --provider-url   the URL where the provider service is running
 
 -u --broker-url     the scheme, domain, and port where the Signet Broker is being hosted (ex. http://localhost:3000)
 
--i --ignore-config  ingore .signetrc.yaml file if it exists
+-i --ignore-config  ingore .signetrc.yaml file if it exists (optional)
 ```
 
 - `.signetrc.yaml` supports these flags for `signet test`:
@@ -137,7 +139,7 @@ flags:
 
 -n --name           the name of the service
 
--v --version        the version of the service
+-v --version        the version of the service (required)
 
 -e --environment    the name of the environment that the service is deployed to (ex. production)
 

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -26,14 +26,12 @@ var publishCmd = &cobra.Command{
 	
 	-n -—name           canonical name of the provider service (only for —-type 'provider')
 	
-	-v -—version        service version (required for --type 'consumer')
-	-—type=consumer: if flag not passed or passed without value, defaults to the git SHA of HEAD
-	-—type=provider: if the flag passed without value, defaults to git SHA
+	-v -—version        service version (only for --type 'consumer', if flag not passed or passed without value, defaults to the git SHA of HEAD)
 	
-	-b -—branch         git branch name (optional, defaults to current git branch)
-
+	-b -—branch         git branch name (optional, only for --type 'consumer', defaults to git branch of HEAD)
+	
 	-u --broker-url     the scheme, domain, and port where the Signet Broker is being hosted (ex. http://localhost:3000)
-
+	
 	-i --ignore-config  ingore .signetrc.yaml file if it exists
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -61,7 +59,7 @@ var publishCmd = &cobra.Command{
 				return err
 			}
 		} else {
-			err = utils.PublishProvider(path, brokerURL, name, version, branch)
+			err = utils.PublishProvider(path, brokerURL, name, "", "")
 			if err != nil {
 				return err
 			}
@@ -76,9 +74,9 @@ func init() {
 
 	publishCmd.Flags().StringVarP(&path, "path", "p", "", "Relative path from the root directory to the contract or spec file")
 	publishCmd.Flags().StringVarP(&serviceType, "type", "t", "", "Type of the participant (\"consumer\" or \"provider\")")
-	publishCmd.Flags().StringVarP(&branch, "branch", "b", "", "Version control branch (optional)")
+	publishCmd.Flags().StringVarP(&branch, "branch", "b", "", "git branch name (optional, only for --type 'consumer', defaults to git branch of HEAD)")
 	publishCmd.Flags().StringVarP(&name, "name", "n", "", "canonical name of the provider service (only for —-type 'provider')")
-	publishCmd.Flags().StringVarP(&version, "version", "v", "", "The version of the service (Defaults to git SHA)")
+	publishCmd.Flags().StringVarP(&version, "version", "v", "", "service version (only for --type 'consumer', if flag not passed or passed without value, defaults to the git SHA of HEAD)")
 	publishCmd.Flags().Lookup("version").NoOptDefVal = "auto"
 	publishCmd.Flags().Lookup("branch").NoOptDefVal = "auto"
 

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -10,7 +10,6 @@ import (
 )
 
 var serviceType string
-var providerName string
 var contractFormat string
 var contract []byte
 
@@ -25,7 +24,7 @@ var publishCmd = &cobra.Command{
 	
 	-t -—type           the type of service contract (either 'consumer' or 'provider')
 	
-	-n -—provider-name  canonical name of the provider service (only for —-type 'provider')
+	-n -—name           canonical name of the provider service (only for —-type 'provider')
 	
 	-v -—version        service version (required for --type 'consumer')
 	-—type=consumer: if flag not passed or passed without value, defaults to the git SHA of HEAD
@@ -41,7 +40,7 @@ var publishCmd = &cobra.Command{
 		// get flag values from config file if not passed in on command line
 		path = viper.GetString("publish.path")
 		serviceType = viper.GetString("publish.type")
-		providerName = viper.GetString("publish.provider-name")
+		name = viper.GetString("publish.name")
 
 		if len(path) == 0 {
 			return errors.New("No --path to a contract/spec was provided. This is a required flag.")
@@ -62,7 +61,7 @@ var publishCmd = &cobra.Command{
 				return err
 			}
 		} else {
-			err = utils.PublishProvider(path, brokerURL, providerName, version, branch)
+			err = utils.PublishProvider(path, brokerURL, name, version, branch)
 			if err != nil {
 				return err
 			}
@@ -78,12 +77,12 @@ func init() {
 	publishCmd.Flags().StringVarP(&path, "path", "p", "", "Relative path from the root directory to the contract or spec file")
 	publishCmd.Flags().StringVarP(&serviceType, "type", "t", "", "Type of the participant (\"consumer\" or \"provider\")")
 	publishCmd.Flags().StringVarP(&branch, "branch", "b", "", "Version control branch (optional)")
-	publishCmd.Flags().StringVarP(&providerName, "provider-name", "n", "", "The name of the provider service (required if --type is \"provider\")")
+	publishCmd.Flags().StringVarP(&name, "name", "n", "", "canonical name of the provider service (only for —-type 'provider')")
 	publishCmd.Flags().StringVarP(&version, "version", "v", "", "The version of the service (Defaults to git SHA)")
 	publishCmd.Flags().Lookup("version").NoOptDefVal = "auto"
 	publishCmd.Flags().Lookup("branch").NoOptDefVal = "auto"
 
 	viper.BindPFlag("publish.path", publishCmd.Flags().Lookup("path"))
 	viper.BindPFlag("publish.type", publishCmd.Flags().Lookup("type"))
-	viper.BindPFlag("publish.provider-name", publishCmd.Flags().Lookup("provider-name"))
+	viper.BindPFlag("publish.name", publishCmd.Flags().Lookup("name"))
 }

--- a/cmd/publish_test.go
+++ b/cmd/publish_test.go
@@ -225,14 +225,14 @@ func TestPublishProviderWithVersionAndBranch(t *testing.T) {
 		}
 	})
 
-	t.Run("has correct providerVersion", func(t *testing.T) {
-		if reqBody.ProviderVersion != "version1" {
+	t.Run("does not have providerVersion", func(t *testing.T) {
+		if len(reqBody.ProviderVersion) != 0 {
 			t.Error()
 		}
 	})
 
-	t.Run("has correct providerBranch", func(t *testing.T) {
-		if reqBody.ProviderBranch != "main" {
+	t.Run("does not have providerBranch", func(t *testing.T) {
+		if len(reqBody.ProviderBranch) != 0 {
 			t.Error()
 		}
 	})

--- a/cmd/publish_test.go
+++ b/cmd/publish_test.go
@@ -60,7 +60,7 @@ func TestPublishNoProviderName(t *testing.T) {
 		"--type", "provider",
 	}
 	actual := callPublish(flags)
-	expected := "Error: must set --provider-name if --type is \"provider\""
+	expected := "Error: must set --name if --type is \"provider\""
 
 	actual.startsWith(expected, t)
 	teardown()
@@ -163,7 +163,7 @@ func TestPublishProviderWithoutVersion(t *testing.T) {
 		"--path=../data_test/api-spec.json",
 		"--broker-url", server.URL,
 		"--type", "provider",
-		"--provider-name", "user_service",
+		"--name", "user_service",
 	}
 	actual := callPublish(flags)
 
@@ -213,7 +213,7 @@ func TestPublishProviderWithVersionAndBranch(t *testing.T) {
 		"--path=../data_test/api-spec.json",
 		"--broker-url", server.URL,
 		"--type", "provider",
-		"--provider-name", "user_service",
+		"--name", "user_service",
 		"--version=version1",
 		"--branch=main",
 	}
@@ -248,7 +248,7 @@ func TestPublishProviderYAMLSpec(t *testing.T) {
 		"--path=../data_test/api-spec.yaml",
 		"--broker-url", server.URL,
 		"--type", "provider",
-		"--provider-name", "user_service",
+		"--name", "user_service",
 	}
 	actual := callPublish(flags)
 

--- a/cmd/testing_helpers.go
+++ b/cmd/testing_helpers.go
@@ -16,7 +16,6 @@ func teardown() {
 	path = ""
 	brokerURL = ""
 	branch = ""
-	providerName = ""
 	version = ""
 	contractFormat = ""
 	contract = []byte{}

--- a/cmd/verify_provider_test.go
+++ b/cmd/verify_provider_test.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"io/fs"
 
-	// utils "github.com/contract-testing-framework/broker_cli/utils"
+	utils "github.com/contract-testing-framework/broker_cli/utils"
 )
 
 /* ------------- helpers ------------- */
@@ -114,4 +114,51 @@ func TestSignetCanGetLatestSpec(t *testing.T) {
 		expected := "Error: Failed to write specs/spec file: stop this test here"
 		actual.startsWith(expected, t)
 	})
+}
+
+func TestPublishProviderUtilWithoutVersion(t *testing.T) {
+	server, reqBody := mockServerForJSONReq201Created[utils.ProviderBody](t)
+	defer server.Close()
+
+	path := "../data_test/api-spec.json"
+	brokerURL := server.URL
+	name := "user_service"
+	version := "auto"
+	branch := "developement"
+
+	err := utils.PublishProvider(path, brokerURL, name, version, branch)
+	if err != nil {
+		t.Error()
+	}
+
+	t.Run("has correct providerName", func(t *testing.T) {
+		if reqBody.ProviderName != "user_service" {
+			t.Error()
+		}
+	})
+
+	t.Run("has a providerVersion", func(t *testing.T) {
+		if len(reqBody.ProviderVersion) == 0 {
+			t.Error()
+		}
+	})
+
+	t.Run("has a providerBranch", func(t *testing.T) {
+		if len(reqBody.ProviderBranch) == 0 {
+			t.Error()
+		}
+	})
+
+	t.Run("has correct specFormat", func(t *testing.T) {
+		if reqBody.SpecFormat != "json" {
+			t.Error()
+		}
+	})
+
+	t.Run("has non-nil spec", func(t *testing.T) {
+		if reqBody.Spec == nil {
+			t.Error()
+		}
+	})
+	teardown()
 }

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -167,7 +167,7 @@ func PublishConsumer(path string, brokerURL string, version, branch string) erro
 
 func PublishProvider(path string, brokerURL string, ProviderName, version, branch string) error {
 	if len(ProviderName) == 0 {
-		return errors.New("must set --provider-name if --type is \"provider\"")
+		return errors.New("must set --name if --type is \"provider\"")
 	}
 
 	if branch == "auto" || (branch == "" && version == "auto") {


### PR DESCRIPTION
Now that `signet test` is used to publish provider versions after they are tested against an API spec, 'signet publish' is no longer allowed to publish a providerVersion or providerBranch to the Signet broker.