### PR TITLE
updated register-env flags and added to README

### DIFF
--- a/.signetrc.yaml
+++ b/.signetrc.yaml
@@ -21,3 +21,6 @@ proxy:
   target: http://localhost:3002
   name: service_1
   provider-name: user_service
+
+register-env:
+  environment: production

--- a/README.md
+++ b/README.md
@@ -158,6 +158,32 @@ test:
 signet test --broker-url=http://localhost:3000 --provider-url=http://localhost:3002 --name=example-provider --version=version1 --branch
 ```
 
+## `signet register-env`
+
+- The `register-env` command informs the Signet broker about a new deployment environment. 
+
+```bash
+flags:
+
+-e --environment    the name of the deployment environment being registered (ex. production)
+
+-u --broker-url     the scheme, domain, and port where the Signet Broker is being hosted
+
+-i --ignore-config  ingore .signetrc.yaml file if it exists (optional)
+```
+- `.signetrc.yaml` supports these flags for `update-deployment`:
+```yaml
+broker-url: http://localhost:3000
+
+register-env:
+  environment: production
+```
+
+#### Register a deployment environment (with explicit flags)
+```bash
+signet register-env --broker-url=http://localhost:3000 --environment=production
+```
+
 ## `signet update-deployment`
 
 - The `update-deployment` command informs the Signet broker of which service versions are currently deployed in an environment. If broker does not already know about the `--environment`, it will create it.
@@ -186,7 +212,7 @@ update-deployment:
   environment: production
 ```
 
-#### Notify the Signet broker of a deployment
+#### Notify the Signet broker of a deployment (with explicit flags)
 ```bash
 signet update-deployment --broker-url=http://localhost:3000 --name=example-provider --version=version1 --environment=production
 ```
@@ -220,7 +246,7 @@ broker-url: http://localhost:3000
 deploy-guard:
   name: user_service
 ```
-#### Check if it is safe to deploy a new version of a service
+#### Check if it is safe to deploy a new version of a service (with explicit flags)
 ```bash
 signet deploy-guard --broker-url=http://localhost:3000 --name=example-provider --version=version1 --environment=production
 ```

--- a/cmd/register_env.go
+++ b/cmd/register_env.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	client "github.com/contract-testing-framework/broker_cli/client"
 	utils "github.com/contract-testing-framework/broker_cli/utils"
 )
@@ -16,22 +18,24 @@ var registerEnvCmd = &cobra.Command{
 	
 	flags:
 
-	-n --name           the name of the deployment environment being registered (ex. production)
+	-e --environment    the name of the deployment environment being registered (ex. production)
 
-	-i --ignore-config  ingore .signetrc.yaml file if it exists
-	
-	-u --broker-url     the scheme, domain, and port where the Signet Broker is being hosted (ex. http://localhost:3000)
+	-u --broker-url     the scheme, domain, and port where the Signet Broker is being hosted
+
+	-i --ignore-config  ingore .signetrc.yaml file if it exists (optional)
 	`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		environment = viper.GetString("register-env.environment")
+
 		if len(brokerURL) == 0 {
 			return errors.New("No --broker-url was provided. This is a required flag.")
 		}
 
-		if len(name) == 0 {
-			return errors.New("No --name was provided. A value for this flag is required.")
+		if len(environment) == 0 {
+			return errors.New("No --environment was provided. A value for this flag is required.")
 		}
 
-		requestBody := utils.EnvBody{EnvironmentName: name}
+		requestBody := utils.EnvBody{EnvironmentName: environment}
 
 		jsonData, err := json.Marshal(requestBody)
 		if err != nil {
@@ -50,5 +54,7 @@ var registerEnvCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(registerEnvCmd)
 
-	registerEnvCmd.Flags().StringVarP(&name, "name", "n", "", "The name of the deployment environment being registered")
+	registerEnvCmd.Flags().StringVarP(&environment, "environment", "e", "", "The name of the deployment environment being registered")
+
+	viper.BindPFlag("register-env.environment", registerEnvCmd.Flags().Lookup("environment"))
 }

--- a/cmd/register_env_test.go
+++ b/cmd/register_env_test.go
@@ -22,7 +22,7 @@ func callRegisterEnv(argsAndFlags []string) actualOut {
 
 func TestRegisterEnvNoBrokerURL(t *testing.T) {
 	flags := []string{
-		"--name=production",
+		"--environment=production",
 	}
 	actual := callRegisterEnv(flags)
 	expected := "Error: No --broker-url was provided."
@@ -36,7 +36,7 @@ func TestRegisterEnvNoName(t *testing.T) {
 		"--broker-url=http://localhost:3000",
 	}
 	actual := callRegisterEnv(flags)
-	expected := "Error: No --name was provided."
+	expected := "Error: No --environment was provided."
 
 	actual.startsWith(expected, t)
 	teardown()
@@ -48,7 +48,7 @@ func TestRegisterEnvRequest(t *testing.T) {
 
 	flags := []string{
 		"--broker-url", server.URL,
-		"--name=production",
+		"--environment=production",
 	}
 	actual := callRegisterEnv(flags)
 


### PR DESCRIPTION
this command is necessary in order to use `deploy-guard` if there are no services currently deployed in the environment